### PR TITLE
fix 'no module named future'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ __base__ = {
     'ext_modules':[],
     'ext_package':'',
     'scripts':['scripts/mididump.py', 'scripts/mididumphw.py', 'scripts/midiplay.py'],
+    'install_requires':['future'],
 }
 
 # this kludge ensures we run the build_ext first before anything else
 # otherwise, we will be missing generated files during the copy
 class Install_Command_build_ext_first(setuptools.command.install.install):
     def run(self):
+        setuptools.command.install.install.do_egg_install(self)
         self.run_command("build_ext")
         return setuptools.command.install.install.run(self)
 


### PR DESCRIPTION
installs future alongside midi module on clean install